### PR TITLE
Fix MODE_TO_ZONE

### DIFF
--- a/custom_components/evohome_cc/climate.py
+++ b/custom_components/evohome_cc/climate.py
@@ -93,7 +93,7 @@ MODE_ZONE_TO_HA[ZoneMode.PERMANENT] = MODE_ZONE_TO_HA[ZoneMode.ADVANCED]
 MODE_ZONE_TO_HA[ZoneMode.TEMPORARY] = MODE_ZONE_TO_HA[ZoneMode.ADVANCED]
 
 MODE_TO_ZONE = (ZoneMode.SCHEDULE, ZoneMode.PERMANENT)
-MODE_TO_ZONE = {v: k for k, v in PRESET_TCS_TO_HA.items() if k in MODE_TO_ZONE}
+MODE_TO_ZONE = {v: k for k, v in MODE_ZONE_TO_HA.items() if k in MODE_TO_ZONE}
 PRESET_ZONE_TO_HA = {
     ZoneMode.SCHEDULE: PRESET_NONE,
     ZoneMode.TEMPORARY: "temporary",


### PR DESCRIPTION
Change MODE_TO_ZONE to use the MODE_ZONE_TO_HA instead of the PRESET_TCS_TO_HA as otherwise the hvac_modes of a zone are empty and with this it has selectable values.