### PR TITLE
Optional advanced_override config parameter

### DIFF
--- a/custom_components/evohome_cc/__init__.py
+++ b/custom_components/evohome_cc/__init__.py
@@ -44,6 +44,7 @@ from .schema import (
     DOMAIN_SERVICES,
     SVC_SEND_PACKET,
     normalise_config_schema,
+    CONF_ADVANCED_OVERRIDE,
 )
 from .version import __version__ as VERSION
 
@@ -91,6 +92,9 @@ async def async_setup(hass: HomeAssistantType, hass_config: ConfigType) -> bool:
 
     serial_port, kwargs = normalise_config_schema(dict(hass_config[DOMAIN]))
     client = ramses_rf.Gateway(serial_port, loop=hass.loop, **kwargs)
+    
+    if hass_config[DOMAIN][CONF_ADVANCED_OVERRIDE]:
+        _LOGGER.warning("evohome_cc: advanced_override ENABLED")
 
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][BROKER] = broker = EvoBroker(

--- a/custom_components/evohome_cc/__init__.py
+++ b/custom_components/evohome_cc/__init__.py
@@ -40,11 +40,11 @@ from .const import (
 )
 from .schema import CONFIG_SCHEMA  # noqa: F401
 from .schema import (
+    CONF_ADVANCED_OVERRIDE,
     CONF_RESTORE_STATE,
     DOMAIN_SERVICES,
     SVC_SEND_PACKET,
     normalise_config_schema,
-    CONF_ADVANCED_OVERRIDE,
 )
 from .version import __version__ as VERSION
 
@@ -92,7 +92,7 @@ async def async_setup(hass: HomeAssistantType, hass_config: ConfigType) -> bool:
 
     serial_port, kwargs = normalise_config_schema(dict(hass_config[DOMAIN]))
     client = ramses_rf.Gateway(serial_port, loop=hass.loop, **kwargs)
-    
+
     if hass_config[DOMAIN][CONF_ADVANCED_OVERRIDE]:
         _LOGGER.warning("evohome_cc: advanced_override ENABLED")
 

--- a/custom_components/evohome_cc/climate.py
+++ b/custom_components/evohome_cc/climate.py
@@ -47,6 +47,7 @@ from .schema import (
     CONF_SYSTEM_MODE,
     SVC_RESET_SYSTEM_MODE,
     SVC_SET_SYSTEM_MODE,
+    CONF_ADVANCED_OVERRIDE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -145,6 +146,7 @@ class EvoZone(EvoZoneBase, ClimateEntity):
         self._hvac_modes = list(MODE_TO_ZONE)
         self._preset_modes = list(PRESET_TO_ZONE)
         self._supported_features = SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE
+        self.broker = broker
 
     @property
     def device_state_attributes(self) -> Dict[str, Any]:
@@ -246,7 +248,12 @@ class EvoZone(EvoZoneBase, ClimateEntity):
 
     def set_temperature(self, **kwargs) -> None:  # set_target_temp (aka setpoint)
         """Set a new target temperature."""
-        self.svc_set_zone_mode(setpoint=kwargs.get(ATTR_TEMPERATURE))
+        if self.broker.hass_config[DOMAIN][CONF_ADVANCED_OVERRIDE]:
+            _LOGGER.info("evohome_cc - set temperature with advanced override ENABLED")
+            self.svc_set_zone_mode(mode=ZoneMode.ADVANCED,setpoint=kwargs.get(ATTR_TEMPERATURE))
+        else:
+            _LOGGER.info("evohome_cc - set temperature with advanced override DISABLED")
+            self.svc_set_zone_mode(setpoint=kwargs.get(ATTR_TEMPERATURE))
 
     def svc_reset_zone_config(self) -> None:
         """Reset the configuration of the Zone."""

--- a/custom_components/evohome_cc/climate.py
+++ b/custom_components/evohome_cc/climate.py
@@ -43,11 +43,11 @@ from . import EvoZoneBase
 from .const import ATTR_SETPOINT, BROKER, DATA, DOMAIN, SERVICE, UNIQUE_ID
 from .schema import (
     CLIMATE_SERVICES,
+    CONF_ADVANCED_OVERRIDE,
     CONF_MODE,
     CONF_SYSTEM_MODE,
     SVC_RESET_SYSTEM_MODE,
     SVC_SET_SYSTEM_MODE,
-    CONF_ADVANCED_OVERRIDE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -250,7 +250,9 @@ class EvoZone(EvoZoneBase, ClimateEntity):
         """Set a new target temperature."""
         if self.broker.hass_config[DOMAIN][CONF_ADVANCED_OVERRIDE]:
             _LOGGER.info("evohome_cc - set temperature with advanced override ENABLED")
-            self.svc_set_zone_mode(mode=ZoneMode.ADVANCED,setpoint=kwargs.get(ATTR_TEMPERATURE))
+            self.svc_set_zone_mode(
+                mode=ZoneMode.ADVANCED, setpoint=kwargs.get(ATTR_TEMPERATURE)
+            )
         else:
             _LOGGER.info("evohome_cc - set temperature with advanced override DISABLED")
             self.svc_set_zone_mode(setpoint=kwargs.get(ATTR_TEMPERATURE))

--- a/custom_components/evohome_cc/schema.py
+++ b/custom_components/evohome_cc/schema.py
@@ -54,6 +54,7 @@ SCAN_INTERVAL_DEFAULT = td(seconds=300)
 SCAN_INTERVAL_MINIMUM = td(seconds=10)
 
 CONF_RESTORE_STATE = "restore_state"
+CONF_ADVANCED_OVERRIDE = "advanced_override"
 
 PACKET_LOG_SCHEMA = vol.Schema(
     {
@@ -270,6 +271,7 @@ CONFIG_SCHEMA = vol.Schema(
                 ): vol.All(cv.time_period, vol.Range(min=SCAN_INTERVAL_MINIMUM)),
                 vol.Optional(SVC_SEND_PACKET): bool,
                 vol.Optional(CONF_RESTORE_STATE, default=True): bool,
+                vol.Optional(CONF_ADVANCED_OVERRIDE, default=False): bool,
             },
             extra=vol.ALLOW_EXTRA,  # will be system schemas
         )


### PR DESCRIPTION
Because of the change in default behaviour when setting a zone temperature from advanced_override to permanent_override, this pull request creates a new optional configuration parameter:

```
evohome_cc:
  ...
  advanced_override: true
```

When set to true, the default behaviour for set_temperature is ZoneMode.ADVANCED.
If the parameter is false, or does not exist, the default behaviour is unchanged from before (permanent).

I realise that a change to allow profiles is coming soon, but this is a stop-gap measure until that time to allow those who find the current default behaviour unworkable. It should not affect existing users not interested in this function, and only those who wish to change the default behaviour should add this parameter to the configuration. It will allow me personally to carry on using the latest updates to evohome_cc without having to keep manually diving in to edit climate.py every time.
